### PR TITLE
Freeze lib version for FA, add missing README section for resnet

### DIFF
--- a/NVIDIA/benchmarks/bert/implementations/pytorch/requirements.txt
+++ b/NVIDIA/benchmarks/bert/implementations/pytorch/requirements.txt
@@ -13,3 +13,4 @@ requests==2.23.0
 six==1.15.0
 tensorflow==2.2.0
 git+https://github.com/NVIDIA/mlperf-common.git
+flash_attn==1.0.5

--- a/NVIDIA/benchmarks/gpt3/implementations/pytorch/requirements.txt
+++ b/NVIDIA/benchmarks/gpt3/implementations/pytorch/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/mlcommons/logging.git@3.0.0-rc1
 git+https://github.com/NVIDIA/mlperf-common.git
 zarr==2.13
 tensorstore==0.1.27
+flash_attn==1.0.5

--- a/NVIDIA/benchmarks/resnet/implementations/mxnet/README.md
+++ b/NVIDIA/benchmarks/resnet/implementations/mxnet/README.md
@@ -49,3 +49,27 @@ nvidia-docker run --rm -it --ipc=host -v <path/to/store/raw/&/processed/data>:/d
 ```
 ./scripts/prepare_imagenet.sh <path/to/raw/imagenet> <path/to/save/preprocessed/data>
 ```
+
+## Steps to launch training
+
+### NVIDIA DGX H100
+
+Launch configuration and system-specific hyperparameters for the NVIDIA DGX
+H100 submission are in the `../<implementation>/config_DGXH100_<scale>.sh` script.
+
+Steps required to launch training on NVIDIA DGX H100.  The sbatch
+script assumes a cluster running Slurm with the Pyxis containerization plugin.
+
+1. Build the docker container and push to a docker registry
+
+```
+cd ../pytorch
+docker build --pull -t <docker/registry:benchmark-tag> .
+docker push <docker/registry:benchmark-tag>
+```
+
+2. Launch the training
+```
+source config_DGXH100_<scale>.sh
+CONT=<docker/registry:benchmark-tag> DATADIR=<path/to/data/dir> LOGDIR=<path/to/output/dir> sbatch -N ${DGXNNODES} -t ${WALLTIME} run.sub
+```

--- a/NVIDIA_CoreWeave/benchmarks/bert/implementations/pytorch/requirements.txt
+++ b/NVIDIA_CoreWeave/benchmarks/bert/implementations/pytorch/requirements.txt
@@ -13,3 +13,4 @@ requests==2.23.0
 six==1.15.0
 tensorflow==2.2.0
 git+https://github.com/NVIDIA/mlperf-common.git
+flash_attn==1.0.5

--- a/NVIDIA_CoreWeave/benchmarks/gpt3/implementations/pytorch/requirements.txt
+++ b/NVIDIA_CoreWeave/benchmarks/gpt3/implementations/pytorch/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/mlcommons/logging.git@3.0.0-rc1
 git+https://github.com/NVIDIA/mlperf-common.git
 zarr==2.13
 tensorstore==0.1.27
+flash_attn==1.0.5

--- a/NVIDIA_CoreWeave/benchmarks/resnet/implementations/mxnet/README.md
+++ b/NVIDIA_CoreWeave/benchmarks/resnet/implementations/mxnet/README.md
@@ -49,3 +49,27 @@ nvidia-docker run --rm -it --ipc=host -v <path/to/store/raw/&/processed/data>:/d
 ```
 ./scripts/prepare_imagenet.sh <path/to/raw/imagenet> <path/to/save/preprocessed/data>
 ```
+
+## Steps to launch training
+
+### NVIDIA DGX H100
+
+Launch configuration and system-specific hyperparameters for the NVIDIA DGX
+H100 submission are in the `../<implementation>/config_DGXH100_<scale>.sh` script.
+
+Steps required to launch training on NVIDIA DGX H100.  The sbatch
+script assumes a cluster running Slurm with the Pyxis containerization plugin.
+
+1. Build the docker container and push to a docker registry
+
+```
+cd ../pytorch
+docker build --pull -t <docker/registry:benchmark-tag> .
+docker push <docker/registry:benchmark-tag>
+```
+
+2. Launch the training
+```
+source config_DGXH100_<scale>.sh
+CONT=<docker/registry:benchmark-tag> DATADIR=<path/to/data/dir> LOGDIR=<path/to/output/dir> sbatch -N ${DGXNNODES} -t ${WALLTIME} run.sub
+```


### PR DESCRIPTION
1. Freeze flash_attn version in requirements.txt which is needed to reproduce NVIDIA submission results from v3.0. The code will throw an error without this fix due to version mismatch.
2. The training instructions for resnet were missing in the README, so added that as well.  